### PR TITLE
remove AMD module name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
     },
     mode: 'development',
     output: {
-        library: 'customScript',
         libraryTarget: 'amd',
         path: path.resolve(__dirname, 'dist'),
         filename: '[name].js'


### PR DESCRIPTION
If you want to use a custom script with requirejs you have to know the module name beforehand.
In addition to that, it should also be unique, which we can't ensure.